### PR TITLE
Change wait monitoring from replicacontroller to rollout status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,15 +204,11 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
 
       echo "Applying Deployment ${REPO_NAME}-app..."
       createDeploymentStatus(projectEnv, 'PENDING', hostRouteEnv)
-      openshift.apply(dcApp)
+      def dc = openshift.apply(dcApp).narrow('dc')
 
-      // Wait for all pods to be ready
-      def latestVersion = openshift.selector('dc', "${APP_NAME}-app-${JOB_NAME}").object().status.latestVersion
-      def rc = openshift.selector('rc', "${APP_NAME}-app-${JOB_NAME}-${latestVersion}")
+      // Wait for new deployment to roll out
       timeout(5) {
-        rc.watch {
-          return (it.object().status.readyReplicas == it.object().status.replicas)
-        }
+        dc.rollout().status('--watch=true')
       }
     }
   }

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -179,15 +179,11 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
 
       echo "Applying Deployment ${REPO_NAME}-app..."
       createDeploymentStatus(projectEnv, 'PENDING', hostRouteEnv)
-      openshift.apply(dcApp)
+      def dc = openshift.apply(dcApp).narrow('dc')
 
-      // Wait for all pods to be ready
-      def latestVersion = openshift.selector('dc', "${APP_NAME}-app-${JOB_NAME}").object().status.latestVersion
-      def rc = openshift.selector('rc', "${APP_NAME}-app-${JOB_NAME}-${latestVersion}")
+      // Wait for new deployment to roll out
       timeout(5) {
-        rc.watch {
-          return (it.object().status.readyReplicas == it.object().status.replicas)
-        }
+        dc.rollout().status('--watch=true')
       }
     }
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR waits for releases based on rollout status instead of monitoring the replica controller.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
