### PR TITLE
Email Status Message List

### DIFF
--- a/frontend/src/email/EmailForm.css
+++ b/frontend/src/email/EmailForm.css
@@ -72,3 +72,11 @@
   text-align: left;
   font-size: smaller;
 }
+
+th {
+  font-size: small;
+}
+
+td {
+  font-size: smaller;
+}

--- a/frontend/src/email/EmailForm.jsx
+++ b/frontend/src/email/EmailForm.jsx
@@ -22,6 +22,9 @@ class EmailForm extends Component {
         hasCreateMessage: false,
         cmsgApiHealthy: false,
       },
+      tab: 'sc',
+      messageIds: [],
+      statuses: [],
       info: '',
       error: '',
       dropWarning: '',
@@ -53,6 +56,15 @@ class EmailForm extends Component {
     this.onFileDrop = this.onFileDrop.bind(this);
 
     this.removeFile = this.removeFile.bind(this);
+
+    this.onSelectTab = this.onSelectTab.bind(this);
+  }
+
+  onSelectTab(event) {
+    event.preventDefault();
+    if (this.state.tab !== event.target.id) {
+      this.setState({tab: event.target.id, info: '', error: ''});
+    }
   }
 
   onChangeSubject(event) {
@@ -109,8 +121,11 @@ class EmailForm extends Component {
       let {fileSize, fileCount, fileType} = config.data.attachments;
       let {defaultSender} = config.data;
 
+      let tab = (credentialsGood && credentialsAuthenticated  && hasTopLevel  && hasCreateMessage  && cmsgApiHealthy) ? 'email' : 'sc';
+
       this.setState({
         busy: false,
+        tab: tab,
         healthCheck: {
           credentialsGood: credentialsGood,
           credentialsAuthenticated: credentialsAuthenticated,
@@ -126,9 +141,32 @@ class EmailForm extends Component {
         }
       });
 
+      // every minute, let's go get the status of messages we've sent this session.
+      // could certainly do more work to no longer fetch items that are gateway delivered, but it's just a simple demo.
+
+      this.interval = setInterval(async () => {
+        let messageIds = this.state.messageIds || [];
+        let statuses = this.state.statuses || [];
+        await this.asyncForEach(messageIds, async (id) => {
+          let statusResponse = await this.fetchStatus(id);
+          statusResponse.data.statuses.forEach(s => {
+            let status = s;
+            // don't add it to list of results if it's already there (same message, same recipient, same type of status)
+            if (!statuses.find(x => { return x.messageId === s.messageId && x.recipient === s.recipient && x.type === s.type; })) {
+              status.key = Math.random().toString(36);
+              statuses.unshift(status);
+            }
+          });
+
+        });
+        // update the table data, take them to the status tab
+        this.setState({statuses: statuses, info: '', error: '', tab: 'status'});
+      }, 60000);
+
     } catch (e) {
       this.setState({
         busy: false,
+        tab: 'sc',
         healthCheck: {
           credentialsGood: credentialsGood,
           credentialsAuthenticated: credentialsAuthenticated,
@@ -139,6 +177,10 @@ class EmailForm extends Component {
         error: e.message
       });
     }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
   }
 
   async healthCheck() {
@@ -171,14 +213,27 @@ class EmailForm extends Component {
       this.setState({form: form, info: ''});
       return;
     }
-
+    let messageIds = this.state.messageIds;
+    let statuses = this.state.statuses;
+    let messageId = undefined;
     try {
       if (this.state.healthCheck.hasCreateMessage) {
         this.setState({busy: true});
         let filenames = await this.uploadFiles();
-        await this.postEmail(filenames);
+        let postEmailData = await this.postEmail(filenames);
 
-        // this will reset the form and the tinymce editor...
+        messageId = postEmailData.data.messageId;
+        messageIds.push(messageId);
+
+        // a single status response returns an email status for each recipient
+        // break it down to a row item per msg & recipient
+        let statusResponse = await this.fetchStatus(messageId);
+        statusResponse.data.statuses.forEach(s => {
+          let status = s;
+          status.key = Math.random().toString(36); //need a display key for rendering
+          statuses.unshift(status);
+        });
+
         let form = this.state.form;
         form.wasValidated = false;
         form.recipients = '';
@@ -190,7 +245,9 @@ class EmailForm extends Component {
         form.reset = true;
         this.setState({
           busy:false,
-          form: form
+          form: form,
+          messageIds,
+          statuses: statuses
         });
       }
       // this will show the info message, and prep the tinymce editor for next submit...
@@ -200,8 +257,12 @@ class EmailForm extends Component {
       this.setState({
         busy: false,
         form: form,
-        info: 'Message submitted to Showcase Messaging API'
+        info: `Message submitted to Showcase Messaging API: id = ${messageId}`,
+        error: '',
+        messageIds,
+        statuses: statuses
       });
+
     } catch (e) {
       let form = this.state.form;
       form.wasValidated = false;
@@ -261,6 +322,37 @@ class EmailForm extends Component {
     });
   }
 
+  async fetchStatus(messageId) {
+    const response = await fetch(`${MSG_SERVICE_PATH}/email/${messageId}/status`);
+    if (!response.ok) {
+      throw Error('Could not connect to Showcase Messaging API for health check: ' + response.statusText);
+    }
+    return await response.json().catch(error => {
+      throw Error(error.message);
+    });
+  }
+
+  async asyncForEach(array, callback) {
+    for (let index = 0; index < array.length; index++) {
+      await callback(array[index], index, array);
+    }
+  }
+
+  async refreshStatuses() {
+    let messageIds = this.state.messageIds || [];
+    let statuses = this.state.statuses || [];
+    await this.asyncForEach(messageIds, async (id) => {
+      let statusResponse = await this.fetchStatus(id);
+      statusResponse.data.statuses.forEach(s => {
+        let status = s;
+        status.key = Math.random().toString(36);
+        statuses.unshift(status);
+      });
+
+    });
+    this.setState({messageIds: messageIds, statuses: statuses});
+  }
+
   onFileDrop(acceptedFiles) {
     let dropWarning = `Attachments are limited to ${this.state.config.attachmentsMaxFiles} total files of type ${this.state.config.attachmentsAcceptedType} and under ${this.state.config.attachmentsMaxSize} bytes in size.`;
     let form = this.state.form;
@@ -307,6 +399,13 @@ class EmailForm extends Component {
     const bodyErrorDisplay = (this.state.form.wasValidated && !this.hasMessageBody()) ? {} : {display: 'none'};
     const dropWarningDisplay = (this.state.dropWarning && this.state.dropWarning.length > 0) ? {} : {display: 'none'};
 
+    const emailTabClass = this.state.tab === 'email' ? 'nav-link active' : 'nav-link';
+    const statusTabClass = this.state.tab === 'status' ? 'nav-link active' : 'nav-link';
+    const scTabClass = this.state.tab === 'sc' ? 'nav-link active' : 'nav-link';
+    const emailTabDisplay = this.state.tab === 'email' ? {} : {display: 'none'};
+    const statusTabDisplay = this.state.tab === 'status' ? {} : {display: 'none'};
+    const scTabDisplay = this.state.tab === 'sc' ? {} : {display: 'none'};
+
     return (
       <div className="col-md-8 offset-md-2 order-md-1">
 
@@ -329,124 +428,170 @@ class EmailForm extends Component {
           <div className="alert alert-danger" style={errorDisplay}>
             {this.state.error}
           </div>
-          <h4 className="mb-3">Service Client</h4>
-          <div id="healthCheck">
-            <hr className="mb-4"/>
-            <div className="row">
-              <div className="col-sm-10 hc-text">Service Client credentials</div>
-              <div className="col-sm-2"><span id="credentialsInd" className={credentialsIndClass}></span></div>
-            </div>
-            <div className="row">
-              <div className="col-sm-10 hc-text">Service Client has access to Common Messaging API</div>
-              <div className="col-sm-2"><span id="apiAccessInd" className={apiAccessIndClass}></span></div>
-            </div>
-            <div className="row">
-              <div className="col-sm-10 hc-text">Service Client can send message</div>
-              <div className="col-sm-2"><span id="createMsgInd" className={createMsgIndClass}></span></div>
-            </div>
-            <div className="row">
-              <div className="col-sm-10 hc-text">Common Messaging API available</div>
-              <div className="col-sm-2"><span id="healthCheckInd" className={healthCheckIndClass}></span></div>
+
+          <ul className="nav nav-tabs">
+            <li className="nav-item">
+              <a className={emailTabClass} href="#" id='email' onClick={this.onSelectTab}>Email</a>
+            </li>
+            <li className="nav-item">
+              <a className={statusTabClass} href="#" id='status' onClick={this.onSelectTab}>Statuses</a>
+            </li>
+            <li className="nav-item">
+              <a className={scTabClass} href="#" id='sc' onClick={this.onSelectTab}>Service Client</a>
+            </li>
+          </ul>
+
+          <div id="emailTab" style={emailTabDisplay}>
+            <div className="mb-4"></div>
+            <form id="emailForm" noValidate style={emailFormDisplay} onSubmit={this.formSubmit}
+              className={wasValidated ? 'was-validated' : ''}>
+              <div className="mb-3">
+                <label htmlFor="sender">Sender</label>
+                <input type="text" className="form-control" name="sender"
+                  readOnly required value={this.state.config.sender}/>
+                <div className="invalid-feedback">
+                  Email sender is required.
+                </div>
+              </div>
+
+              <div className="mb-3">
+                <label htmlFor="recipients">Recipients</label>
+                <input type="text" className="form-control" name="recipients"
+                  placeholder="you@example.com (separate multiple by comma)" required
+                  value={this.state.form.recipients} onChange={this.onChangeRecipients}/>
+                <div className="invalid-feedback">
+                  One or more email recipients required.
+                </div>
+              </div>
+
+              <div className="mb-3">
+                <label htmlFor="subject">Subject</label>
+                <input type="text" className="form-control" name="subject" required value={this.state.form.subject}
+                  onChange={this.onChangeSubject}/>
+                <div className="invalid-feedback">
+                  Subject is required.
+                </div>
+              </div>
+
+              <div className="mb-3 row">
+                <div className="col-sm-4">
+                  <label className="mt-1">Body</label>
+                </div>
+                <div className="col-sm-4 offset-sm-4 btn-group btn-group-toggle">
+                  <label className={plainTextButton}>
+                    <input type="radio" defaultChecked={this.state.form.mediaType === MEDIA_TYPES[0]} value={MEDIA_TYPES[0]} name="mediaType" onClick={this.onChangeMediaType} /> Plain Text
+                  </label>
+                  <label className={htmlTextButton}>
+                    <input type="radio" defaultChecked={this.state.form.mediaType === MEDIA_TYPES[1]} value={MEDIA_TYPES[1]} name="mediaType" onClick={this.onChangeMediaType} /> HTML
+                  </label>
+                </div>
+              </div>
+              <div style={plainTextDisplay} >
+                <textarea id="messageText" name="plainText" className="form-control" required={this.state.form.mediaType === MEDIA_TYPES[0]}
+                  value={this.state.form.plainText} onChange={this.onChangePlainText}></textarea>
+                <div className="invalid-feedback" style={bodyErrorDisplay}>
+                  Body is required.
+                </div>
+              </div>
+              <div style={htmlTextDisplay} >
+                <TinyMceEditor
+                  id="htmlText"
+                  reset={this.state.form.reset}
+                  onEditorChange={this.onEditorChange}
+                />
+                <div className="invalid-tinymce" style={bodyErrorDisplay}>
+                  Body is required.
+                </div>
+              </div>
+
+              <div className="mt-3 mb-3">
+                <label htmlFor="attachments">Attachments</label>
+              </div>
+              <div className="row">
+                <div className="col-sm-4">
+                  <Dropzone
+                    onDrop={this.onFileDrop}
+                    accept={this.state.config.attachmentsAcceptedType}
+                    maxSize={this.state.config.attachmentsMaxSize}>
+                    {({getRootProps, getInputProps}) => (
+                      <div {...getRootProps({className: 'dropzone'})}>
+                        <input type="file" multiple {...getInputProps({className: 'dropzone-fileinput'})} />
+                        <i className="m-sm-auto fas fa-2x fa-file-pdf upload-icon" alt="upload pdf"></i>
+                      </div>
+                    )}
+                  </Dropzone>
+                </div>
+                <div className="col-sm-8">
+                  {this.state.form.files.map(file => {
+                    return (
+                      <div key={file.name} className="row">
+                        <div className="col-sm-7 dropzone-file m-auto">{file.name}</div>
+                        <div className="col-sm-1 m-auto"><button type="button" className="btn btn-sm" onClick={() => { this.removeFile(file.name); }}><i className="far fa-trash-alt"></i></button></div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+              <div className="alert alert-warning mt-2" style={dropWarningDisplay}>
+                {this.state.dropWarning}
+              </div>
+              <hr className="mb-4"/>
+              <button className="btn btn-primary btn-lg btn-block" type="submit">Send Message</button>
+            </form>
+          </div>
+
+          <div id="statusTab" style={statusTabDisplay}>
+            <div className="mb-4"></div>
+            <div id="messageStatuses">
+              <div className="table-responsive-sm">
+                <table className="table table-striped table-sm">
+                  <thead>
+                    <tr>
+                      <th>Message ID</th>
+                      <th>Recipient</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {this.state.statuses.map((status, idx) => {
+                      return (
+                        <tr key={idx}>
+                          <td>{status.messageId}</td>
+                          <td>{status.recipient}</td>
+                          <td>{status.type}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
 
-          <hr className="mb-4"/>
-          <form id="emailForm" noValidate style={emailFormDisplay} onSubmit={this.formSubmit}
-            className={wasValidated ? 'was-validated' : ''}>
-            <h4 className="mb-3">Email</h4>
-            <div className="mb-3">
-              <label htmlFor="sender">Sender</label>
-              <input type="text" className="form-control" name="sender"
-                readOnly required value={this.state.config.sender}/>
-              <div className="invalid-feedback">
-                Email sender is required.
+          <div id="scTab" style={scTabDisplay}>
+            <div className="mb-4"></div>
+            <div id="healthCheck">
+              <div className="row">
+                <div className="col-sm-10 hc-text">Service Client credentials</div>
+                <div className="col-sm-2"><span id="credentialsInd" className={credentialsIndClass}></span></div>
+              </div>
+              <div className="row">
+                <div className="col-sm-10 hc-text">Service Client has access to Common Messaging API</div>
+                <div className="col-sm-2"><span id="apiAccessInd" className={apiAccessIndClass}></span></div>
+              </div>
+              <div className="row">
+                <div className="col-sm-10 hc-text">Service Client can send message</div>
+                <div className="col-sm-2"><span id="createMsgInd" className={createMsgIndClass}></span></div>
+              </div>
+              <div className="row">
+                <div className="col-sm-10 hc-text">Common Messaging API available</div>
+                <div className="col-sm-2"><span id="healthCheckInd" className={healthCheckIndClass}></span></div>
               </div>
             </div>
+          </div>
 
-            <div className="mb-3">
-              <label htmlFor="recipients">Recipients</label>
-              <input type="text" className="form-control" name="recipients"
-                placeholder="you@example.com (separate multiple by comma)" required
-                value={this.state.form.recipients} onChange={this.onChangeRecipients}/>
-              <div className="invalid-feedback">
-                One or more email recipients required.
-              </div>
-            </div>
 
-            <div className="mb-3">
-              <label htmlFor="subject">Subject</label>
-              <input type="text" className="form-control" name="subject" required value={this.state.form.subject}
-                onChange={this.onChangeSubject}/>
-              <div className="invalid-feedback">
-                Subject is required.
-              </div>
-            </div>
 
-            <div className="mb-3 row">
-              <div className="col-sm-4">
-                <label className="mt-1">Body</label>
-              </div>
-              <div className="col-sm-4 offset-sm-4 btn-group btn-group-toggle">
-                <label className={plainTextButton}>
-                  <input type="radio" defaultChecked={this.state.form.mediaType === MEDIA_TYPES[0]} value={MEDIA_TYPES[0]} name="mediaType" onClick={this.onChangeMediaType} /> Plain Text
-                </label>
-                <label className={htmlTextButton}>
-                  <input type="radio" defaultChecked={this.state.form.mediaType === MEDIA_TYPES[1]} value={MEDIA_TYPES[1]} name="mediaType" onClick={this.onChangeMediaType} /> HTML
-                </label>
-              </div>
-            </div>
-            <div style={plainTextDisplay} >
-              <textarea id="messageText" name="plainText" className="form-control" required={this.state.form.mediaType === MEDIA_TYPES[0]}
-                value={this.state.form.plainText} onChange={this.onChangePlainText}></textarea>
-              <div className="invalid-feedback" style={bodyErrorDisplay}>
-                Body is required.
-              </div>
-            </div>
-            <div style={htmlTextDisplay} >
-              <TinyMceEditor
-                id="htmlText"
-                reset={this.state.form.reset}
-                onEditorChange={this.onEditorChange}
-              />
-              <div className="invalid-tinymce" style={bodyErrorDisplay}>
-                Body is required.
-              </div>
-            </div>
-
-            <div className="mt-3 mb-3">
-              <label htmlFor="attachments">Attachments</label>
-            </div>
-            <div className="row">
-              <div className="col-sm-4">
-                <Dropzone
-                  onDrop={this.onFileDrop}
-                  accept={this.state.config.attachmentsAcceptedType}
-                  maxSize={this.state.config.attachmentsMaxSize}>
-                  {({getRootProps, getInputProps}) => (
-                    <div {...getRootProps({className: 'dropzone'})}>
-                      <input type="file" multiple {...getInputProps({className: 'dropzone-fileinput'})} />
-                      <i className="m-sm-auto fas fa-2x fa-file-pdf upload-icon" alt="upload pdf"></i>
-                    </div>
-                  )}
-                </Dropzone>
-              </div>
-              <div className="col-sm-8">
-                {this.state.form.files.map(file => {
-                  return (
-                    <div key={file.name} className="row">
-                      <div className="col-sm-7 dropzone-file m-auto">{file.name}</div>
-                      <div className="col-sm-1 m-auto"><button type="button" className="btn btn-sm" onClick={() => { this.removeFile(file.name); }}><i className="far fa-trash-alt"></i></button></div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-            <div className="alert alert-warning mt-2" style={dropWarningDisplay}>
-              {this.state.dropWarning}
-            </div>
-            <hr className="mb-4"/>
-            <button className="btn btn-primary btn-lg btn-block" type="submit">Send Message</button>
-          </form>
         </div>
       </div>
     );


### PR DESCRIPTION
add a section for displaying status results (keep polling), add tabs to ui.

<!-- Provide a general summary of your changes in the Title above -->
# Description
Showcase the email messages status API call.  Call immediately after sending email, and continue polling to show different statuses. 

Message Ids only last the duration of the page, a refresh or a reload will lose the ids.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->