### PR TITLE
Add namespace and service account selectors to NSP

### DIFF
--- a/openshift/ches-backend.dc.yaml
+++ b/openshift/ches-backend.dc.yaml
@@ -8,15 +8,16 @@ metadata:
   name: "${APP_NAME}-${JOB_NAME}-ches-dc"
 objects:
 
-  - kind: NetworkSecurityPolicy
-    apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+  - apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+    kind: NetworkSecurityPolicy
     metadata:
       name: "${APP_NAME}-${JOB_NAME}-ches-backend-to-egress-${NAMESPACE}"
     spec:
       description: |
         Allow ches-backend to open connections to the internet
       source:
-        - - "app=${APP_NAME}-${JOB_NAME}"
+        - - "$namespace=${NAMESPACE}"
+          - "app=${APP_NAME}-${JOB_NAME}"
           - "deploymentconfig=${APP_NAME}-${JOB_NAME}-ches-backend"
           - role=ches-backend
       destination:

--- a/openshift/reverse-proxy.dc.yaml
+++ b/openshift/reverse-proxy.dc.yaml
@@ -10,12 +10,13 @@ objects:
 - apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
   kind: NetworkSecurityPolicy
   metadata:
-    name: "${APP_NAME}-${JOB_NAME}-pods-to-k8s-api-${NAMESPACE}"
+    name: "${APP_NAME}-${JOB_NAME}-sa-protector-to-k8s-api-${NAMESPACE}"
   spec:
     description: |
       Allow pods to talk to the internal K8S api
     source:
-      - - $namespace=${NAMESPACE}
+      - - "$namespace=${NAMESPACE}"
+        - "@app:k8s:serviceaccountname=deployer"
     destination:
       - - int:network=internal-cluster-api-endpoint
 - kind: NetworkSecurityPolicy
@@ -26,15 +27,19 @@ objects:
     description: |
       Allow reverse-proxy to connect to frontend, backend and ches-backend
     source:
-      - - "app=${APP_NAME}-${JOB_NAME}"
+      - - "$namespace=${NAMESPACE}"
+        - "app=${APP_NAME}-${JOB_NAME}"
         - "deploymentconfig=${APP_NAME}-${JOB_NAME}-reverse-proxy"
         - role=reverse-proxy
     destination:
-      - - "app=${APP_NAME}-${JOB_NAME}"
+      - - "$namespace=${NAMESPACE}"
+        - "app=${APP_NAME}-${JOB_NAME}"
         - role=frontend
-      - - "app=${APP_NAME}-${JOB_NAME}"
+      - - "$namespace=${NAMESPACE}"
+        - "app=${APP_NAME}-${JOB_NAME}"
         - role=backend
-      - - "app=${APP_NAME}-${JOB_NAME}"
+      - - "$namespace=${NAMESPACE}"
+        - "app=${APP_NAME}-${JOB_NAME}"
         - role=ches-backend
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR ensures that traffic only goes within the same namespace. It also further restricts k8s API access to just the deployer service account.
<!-- Why is this change required? What problem does it solve? -->
This improves our NSP alignment with Trust No One principles.
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
